### PR TITLE
Reddit API now has SSL Support. 

### DIFF
--- a/OrangeredAppDelegate.m
+++ b/OrangeredAppDelegate.m
@@ -209,7 +209,7 @@ static const int AppUpdatePollInterval    = (60 * 60 * 24); // 1 day
 	
 	OrangeLog(@"Logging in user: %@", self.prefs.name);
 	
-	NSURL* url = [NSURL URLWithString:@"http://www.reddit.com/api/login"];
+	NSURL* url = [NSURL URLWithString:@"https://ssl.reddit.com/api/login"];
 	
 	NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:url
 														   cachePolicy:NSURLRequestUseProtocolCachePolicy


### PR DESCRIPTION
Changed login url to "https://ssl.reddit.com/api/login"

Official Reddit SSL Announcement: http://www.reddit.com/r/changelog/comments/l4n6y/reddit_change_log_in_with_ssl_javascript_fixes/
