### PR TITLE
Converted to SWIFT 4, Fixed build, Update Compilers, Make High Sierra compatible & a working build

### DIFF
--- a/Orangered-Swift/Info.plist
+++ b/Orangered-Swift/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.1</string>
+	<string>3.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>8</string>
+	<string>1</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>
@@ -29,7 +29,7 @@
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2016 Rockwood Software. All rights reserved.</string>
+	<string>Copyright © 2018 Rockwood Software. All rights reserved.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 </dict>

--- a/Orangered-Swift/LoginViewController.swift
+++ b/Orangered-Swift/LoginViewController.swift
@@ -26,7 +26,7 @@ class LoginViewController: NSViewController {
         loginAction = action
 
         // Effit, force the return. I want to override init (unfailable override), but I am required to call a failable initializer because it's the designated init.
-        super.init(nibName: nil, bundle: nil)!
+        super.init(nibName: nil, bundle: nil)
         
         title = NSLocalizedString("Orangered! Login", comment: "The login window title")
     }
@@ -124,7 +124,7 @@ class LoginViewController: NSViewController {
     
     @objc fileprivate func helpClicked() {
         if let urlActual = kHelpURL {
-            NSWorkspace.shared().open(urlActual)
+            NSWorkspace.shared.open(urlActual)
         }
         else {
             print("Umm, fix your url?")

--- a/Orangered-Swift/StatusItemController.swift
+++ b/Orangered-Swift/StatusItemController.swift
@@ -58,12 +58,12 @@ class StatusItemController: NSObject, NSUserNotificationCenterDelegate {
                 name = "alt-\(basename)"
             }
 
-            if appearanceName == NSAppearanceNameVibrantDark {
+            if appearanceName == NSAppearance.Name.vibrantDark.rawValue {
                 name = "\(name)-dark"
             }
             
             
-            guard let image = NSImage(named: name) else {
+            guard let image = NSImage(named: NSImage.Name(rawValue: name)) else {
                 fatalError("fix yo assets, missing image: \(name)")
             }
             
@@ -86,7 +86,7 @@ class StatusItemController: NSObject, NSUserNotificationCenterDelegate {
         }
     }
     
-    fileprivate let statusItem = NSStatusBar.system().statusItem(withLength: NSSquareStatusItemLength)
+    fileprivate let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
     
     fileprivate var statusPoller:Timer?
     fileprivate let prefs = UserDefaults.standard
@@ -156,7 +156,7 @@ class StatusItemController: NSObject, NSUserNotificationCenterDelegate {
             altImageName = "alt-\(altImageName)"
         }
         
-        statusItem.alternateImage = NSImage(named: altImageName)
+        statusItem.alternateImage = NSImage(named: NSImage.Name(rawValue: altImageName))
         updateIcon()
     }
     
@@ -251,7 +251,7 @@ class StatusItemController: NSObject, NSUserNotificationCenterDelegate {
         }
         
         let window = NSPanel(contentViewController: login)
-        window.appearance = NSAppearance(named: NSAppearanceNameVibrantLight)
+        window.appearance = NSAppearance(named: NSAppearance.Name.vibrantLight)
         loginWindowController = NSWindowController(window: window)
         
         NSApp.activate(ignoringOtherApps: true)
@@ -333,7 +333,7 @@ class StatusItemController: NSObject, NSUserNotificationCenterDelegate {
     }
     
     private func updateIcon() {
-        statusItem.image = state.image(forAppearance: statusItem.button!.effectiveAppearance.name, useAlt: prefs.useAltImages)
+        statusItem.image = state.image(forAppearance: statusItem.button!.effectiveAppearance.name.rawValue, useAlt: prefs.useAltImages)
     }
     
     private func notifyMail() {
@@ -355,7 +355,7 @@ class StatusItemController: NSObject, NSUserNotificationCenterDelegate {
     
     private func openMailbox() {
         if let url = state.mailboxUrl() {
-            NSWorkspace.shared().open(url)
+            NSWorkspace.shared.open(url)
         }
         
         // There's no reasonable way to know when reddit has cleared the unread flag, so we just wait a bit and check again.
@@ -396,7 +396,7 @@ class StatusItemController: NSObject, NSUserNotificationCenterDelegate {
     }
     
     @objc private func quit() {
-        NSApplication.shared().stop(nil)
+        NSApplication.shared.stop(nil)
     }
     
     @objc func handleLoginItemSelected() {

--- a/Orangered-Swift/main.swift
+++ b/Orangered-Swift/main.swift
@@ -9,7 +9,7 @@
 import AppKit
 
 autoreleasepool { () -> () in
-    let app = NSApplication.shared()
+    let app = NSApplication.shared
     let delegate = AppDelegate()
     app.delegate = delegate
     app.run()

--- a/Orangered.xcodeproj/project.pbxproj
+++ b/Orangered.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -142,18 +142,17 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0800;
-				ORGANIZATIONNAME = "Rockwood Software";
+				LastUpgradeCheck = 0940;
+				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					E7591DB71CFB60450074F56B = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = SR7K2S8GE4;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0940;
 					};
 				};
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "Orangered" */;
-			compatibilityVersion = "Xcode 3.2";
+			compatibilityVersion = "Xcode 9.3";
 			developmentRegion = English;
 			hasScannedForEncodings = 1;
 			knownRegions = (
@@ -202,17 +201,35 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "Mac Developer: Sam McLeod-Jones (S64522742G)";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
 				LLVM_LTO = NO;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SDKROOT = macosx;
 				VALID_ARCHS = x86_64;
@@ -226,9 +243,11 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_USE_OPTIMIZATION_PROFILE = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
@@ -242,15 +261,20 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = CY7M7TQ6AY;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				INFOPLIST_FILE = "Orangered-Swift/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rockwood.Orangered;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -260,9 +284,11 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_USE_OPTIMIZATION_PROFILE = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
@@ -276,16 +302,22 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = CY7M7TQ6AY;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				INFOPLIST_FILE = "Orangered-Swift/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rockwood.Orangered;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/Orangered.xcodeproj/project.pbxproj
+++ b/Orangered.xcodeproj/project.pbxproj
@@ -143,9 +143,10 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
 				LastUpgradeCheck = 0940;
-				ORGANIZATIONNAME = "";
+				ORGANIZATIONNAME = "Rockwood Software";
 				TargetAttributes = {
 					E7591DB71CFB60450074F56B = {
+						DevelopmentTeam = SR7K2S8GE4;
 						CreatedOnToolsVersion = 7.3.1;
 						LastSwiftMigration = 0940;
 					};
@@ -218,7 +219,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "Mac Developer: Sam McLeod-Jones (S64522742G)";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_NO_COMMON_BLOCKS = YES;

--- a/Orangered.xcodeproj/xcshareddata/xcschemes/Orangered.xcscheme
+++ b/Orangered.xcodeproj/xcshareddata/xcschemes/Orangered.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0940"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -45,11 +45,11 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableAddressSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
-      enableAddressSanitizer = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable


### PR DESCRIPTION
* Converted to SWIFT 4
* Fixed build
* Updated compilers
* Currently signed with my developer certificate
* Runs on High Sierra 10.13.6
* Built DMG attached

Note: There are still some deprecation warnings in xcode - but nothing serious and it builds without error.

Working build: [Orangered 3.0.0.dmg.zip](https://github.com/voidref/orangered/files/2199564/Orangered.3.0.0.dmg.zip)

App:
![orangered 3 app](https://user-images.githubusercontent.com/862951/42787604-85f8c1bc-899e-11e8-9fc8-7e97a02506a2.jpg)

Logged out:
![orangered 3 logged out](https://user-images.githubusercontent.com/862951/42787580-6c7a247e-899e-11e8-907e-fb652edd8b73.jpg)

Logged in:
![orangered 3 logged in](https://user-images.githubusercontent.com/862951/42787581-6cbe7020-899e-11e8-86da-a893913e66ce.jpg)

Running memory (logged in):
![orangered 3 memory](https://user-images.githubusercontent.com/862951/42787665-dc3ab85a-899e-11e8-8065-a1eca01f067c.jpg)

Running stats (logged in):
![orangered 3 running stats](https://user-images.githubusercontent.com/862951/42787671-e63ac14c-899e-11e8-9fa1-05ca03d44fb1.jpg)

cc/ @voidref 